### PR TITLE
[Fix] 사업 활동 QA 반영

### DIFF
--- a/src/routes/activity/Activity.jsx
+++ b/src/routes/activity/Activity.jsx
@@ -21,8 +21,8 @@ function Activity() {
   // 연도 상태 공유
   const [year, setYear] = useState(2025);
 
-  // 360px ~ 767px
-  const isMobileYearTabs = useMediaQuery('(min-width: 360px) and (max-width: 767px)');
+  // ~ 767px
+  const isMobileYearTabs = useMediaQuery(' (max-width: 767px)');
 
   return (
     <A.Activity>

--- a/src/routes/activity/components/FutureActivityStyle.js
+++ b/src/routes/activity/components/FutureActivityStyle.js
@@ -8,14 +8,14 @@ export const Contianer = styled.div`
   gap: 20px;
   width: 100%;
 
-  /* 360~767px: 좌우 여백 줄이기 */
-  @media (min-width: 360px) and (max-width: 767px) {
+  /* ~767px: 좌우 여백 줄이기 */
+  @media (max-width: 767px) {
     flex-direction: column;
   }
 `;
 
 export const FelxBox = styled.div`
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     display: flex;
     align-items: flex-start;
   }
@@ -32,7 +32,7 @@ export const Box = styled.div`
   border-radius: 10px;
   border: 1px solid ${palette.hover.back2};
   background: ${palette.background.white};
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     padding: 20px;
   }
 `;
@@ -41,8 +41,8 @@ export const Year = styled.div`
   color: ${palette.text.secondary};
   font-size: 18px;
   font-weight: 400;
-  margin: 3px 0 0;
-  @media (min-width: 360px) and (max-width: 767px) {
+  margin: 3.5px 0 0;
+  @media (max-width: 767px) {
     font-size: 14px;
     margin-right: 3px;
   }

--- a/src/routes/activity/components/PhotoAndVideo.jsx
+++ b/src/routes/activity/components/PhotoAndVideo.jsx
@@ -60,7 +60,7 @@ export default function PhotoAndVideo({
   const playlistId = useMemo(() => getPlaylistId(playlist), [playlist]);
 
   // 모바일(360~767)
-  const isMobile = useMediaQuery('(min-width: 360px) and (max-width: 767px)');
+  const isMobile = useMediaQuery('(min-width: 0px) and (max-width: 767px)');
   const scrollerRef = useRef(null);
 
   // 썸네일 데이터만 불러옴

--- a/src/routes/activity/components/PhotoAndVideoStyle.js
+++ b/src/routes/activity/components/PhotoAndVideoStyle.js
@@ -14,8 +14,9 @@ export const Grid = styled.div`
   @media (max-width: 960px) {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  @media (max-width: 560px) {
+  @media (max-width: 767px) {
     grid-template-columns: 1fr;
+    padding: 0px;
   }
 `;
 
@@ -143,11 +144,11 @@ export const ErrorMsg = styled.div`
   font-size: 14px;
 `;
 
-/* 모바일(360–767px) */
+/* 모바일( ~ 767px) */
 export const MobileScroller = styled.div`
   /* 가로 슬라이더 컨테이너 */
   display: none;
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     display: flex;
     overflow-x: auto;
     gap: 12px;
@@ -165,9 +166,9 @@ export const MobileScroller = styled.div`
 
 /* 슬라이드 아이템 (카드 확장) */
 export const MobileCard = styled(Card)`
-  @media (min-width: 360px) and (max-width: 767px) {
-    aspect-ratio: auto; /* Card 기본 16/9 비율 무효화 */
-    flex: 0 0 180px; /* 슬라이드 한 칸 폭 고정 */
+  @media (max-width: 767px) {
+    aspect-ratio: auto;
+    flex: 0 0 180px;
     width: 180px;
     height: 101px;
     scroll-snap-align: start;
@@ -177,8 +178,8 @@ export const MobileCard = styled(Card)`
 /* 슬라이드 아래 큰 플레이어 */
 export const MobileExpanded = styled.div`
   display: none;
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     display: block;
-    padding: 8px 12px 0;
+    padding-top: 20px;
   }
 `;

--- a/src/routes/activity/components/ResultsStyle.js
+++ b/src/routes/activity/components/ResultsStyle.js
@@ -25,13 +25,13 @@ export const Box = styled.div`
   border: 1px solid ${palette.hover.back2};
   background: ${palette.background.white};
 
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     padding: 20px;
   }
 `;
 
 export const FlexBox = styled.div`
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     display: flex;
     align-items: flex-start;
   }
@@ -41,9 +41,9 @@ export const Year = styled.div`
   color: ${palette.text.secondary};
   font-size: 18px;
   font-weight: 400;
-  margin: 3px 0 0;
+  margin: 3.5px 0 0;
 
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     font-size: 14px;
     margin-right: 3px;
   }

--- a/src/routes/activity/components/ScheduleCalendar.jsx
+++ b/src/routes/activity/components/ScheduleCalendar.jsx
@@ -72,8 +72,8 @@ export default function MajorScheduleCalendar({
   pageSize = 5,
 }) {
   const init = initialMonth ? toDate(initialMonth) : new Date();
-  const [viewYear, setViewYear] = useState(init.getFullYear());
-  const [viewMonth, setViewMonth] = useState(init.getMonth());
+  const [viewYear, setViewYear] = useState(startOfDayLocal(new Date()).getFullYear());
+  const [viewMonth, setViewMonth] = useState(startOfDayLocal(new Date()).getMonth());
   const [selectedDate, setSelectedDate] = useState(null);
   const [page, setPage] = useState(0);
 
@@ -139,8 +139,17 @@ export default function MajorScheduleCalendar({
     onDateSelect && onDateSelect(null);
   };
   const handleSelect = (d) => {
-    setSelectedDate(d);
-    onDateSelect && onDateSelect(d);
+    const isSame = selectedDate && dateKey(selectedDate) === dateKey(d);
+
+    if (isSame) {
+      // 같은 날짜 다시 클릭 시 선택 해제
+      setSelectedDate(null);
+      onDateSelect && onDateSelect(null);
+    } else {
+      // 다른 날짜 클릭 시 해당 날짜 선택
+      setSelectedDate(d);
+      onDateSelect && onDateSelect(d);
+    }
   };
 
   const cells = [];

--- a/src/routes/activity/components/ScheduleCalendarStyle.js
+++ b/src/routes/activity/components/ScheduleCalendarStyle.js
@@ -3,15 +3,16 @@ import palette from '@styles/theme';
 
 export const Wrap = styled.section`
   width: 100%;
-  background: #fff;
   border-radius: 16px;
   margin: 0 auto;
 `;
 
 export const CalendarArea = styled.div`
-  width: clamp(300px, 92vw, 360px);
+  width: 100%;
+  max-width: 438px;
   margin: 0 auto;
-  padding: 0 8px;
+  box-sizing: border-box;
+  --cell-size: clamp(32px, calc((100% - 6 * 8px) / 7), 44px);
 `;
 
 export const Header = styled.div`
@@ -32,14 +33,13 @@ export const ArrowButton = styled.button`
   width: 28px;
   height: 28px;
   border-radius: 999px;
-  border: 1px solid #e5e7eb;
-  background: #f9fafb;
+  background: ${palette.hover.back1};
   color: #4b5563;
   display: grid;
   place-items: center;
   cursor: pointer;
   &:hover {
-    background: #eef2ff;
+    background: rgb(231, 232, 239);
   }
 `;
 
@@ -56,16 +56,20 @@ export const WeekHeader = styled.div`
 export const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 8px;
+  box-sizing: border-box;
+  gap: 8px; /* 셀 간격 복구/유지 */
   padding: 0 8px 12px;
 `;
 
 export const Empty = styled.div`
-  height: 44px;
+  width: 100%;
+  aspect-ratio: 1 / 1; /* 빈 칸도 정사각형로 맞춤 */
 `;
 
 export const DayCell = styled.button`
-  height: 44px;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
   border-radius: 10px;
   background: #ffffff;
   position: relative;
@@ -88,6 +92,12 @@ export const DayCell = styled.button`
     background: ${palette.hover.back2};
   }
   &:hover {
+    background: ${palette.hover.back2};
+  }
+  &&:not([data-selected]):hover {
+    background: ${palette.hover.back1};
+  }
+  &&:not([data-selected]):active {
     background: ${palette.hover.back2};
   }
 `;
@@ -113,7 +123,7 @@ export const EmptyList = styled.div`
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 0 8px 8px;
+  padding: 30px 8px 8px;
 `;
 
 export const EmptyText = styled.div`
@@ -148,16 +158,16 @@ export const DateBadge = styled.span`
 `;
 
 export const ListContainer = styled.div`
-  width: clamp(320px, 92vw, 1040px);
+  width: clamp(92vw, 1040px);
   margin: 16px auto 0;
-  padding: 0 8px;
+  padding: 0;
 `;
 
 export const List = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 0 8px 12px;
+  padding: 0 0px 12px;
 `;
 
 export const ListItem = styled.li`
@@ -169,12 +179,15 @@ export const ListItem = styled.li`
   border-radius: 16px;
   border: 1px solid #eef2f7;
   background: #fff;
+  &:hover {
+    box-shadow: 0 0 15px rgba(17, 34, 6, 0.1);
+  }
 
   @media (max-width: 520px) {
     grid-template-columns: 1fr;
     gap: 10px;
   }
-  @media (min-width: 360px) and (max-width: 767px) {
+  @media (max-width: 767px) {
     padding: 20px;
   }
 

--- a/src/routes/activity/components/YearTimelineStyle.js
+++ b/src/routes/activity/components/YearTimelineStyle.js
@@ -24,7 +24,7 @@ export const Rail = styled.div`
   top: 0;
   bottom: 0;
   width: 2px;
-  height: 320px; /* 기존 코드 유지 */
+  height: 320px;
   background: linear-gradient(180deg, ${(p) => p.$rail} 0%, ${(p) => p.$rail} 75%, rgba(152, 161, 189, 0) 100%);
   border-radius: 1px;
   z-index: 1;
@@ -39,7 +39,7 @@ export const YearLabel = styled.div`
   grid-column: 1;
   user-select: none;
   font-weight: ${(p) => (p.$active ? 800 : 600)};
-  font-size: ${(p) => (p.$active ? '28px' : '24px')};
+  font-size: 20px;
   line-height: 1;
   color: ${(p) => (p.$active ? p.$primary : p.$muted)};
   cursor: ${(p) => (p.onClick ? 'pointer' : 'default')};

--- a/src/routes/activity/components/YearTimelineStyle.js
+++ b/src/routes/activity/components/YearTimelineStyle.js
@@ -12,7 +12,7 @@ export const Grid = styled.div`
   grid-template-columns: auto 24px; /* 왼쪽: 연도, 오른쪽: 점 */
   grid-auto-rows: auto;
   align-content: start;
-  align-items: start;
+  align-items: center;
   column-gap: 16px;
   row-gap: 72px;
 `;


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호 

- close #3 

### ✨️ 작업 내용

- [x] Width 360 이하 구간 모바일 UI 적용
- [ ] 새로고침시 주요일정 달력 이번달로 표시되게 수정
- [ ] 주요 일정 달력, 카드 오른쪽 쏠림
- [ ] 디자인 이슈인지 일정이 있는 경우, 없는 경우 차이가 큼
- [ ] 영상 콘텐츠 재생시 줄 밀림
- [ ] 달력 같은 날짜 클릭시 선택 해제
- [ ] 모바일일 경우에 년도, 제목 위아래 가운데 정렬 필요
- [ ] 캘린더 및 일정 카드 hover 미적용 (피그마 참고)
- [ ] hover 효과 300ms ease 추가
- [ ] 연도별/분기별 계획표 현재 연도와 다른 연도 텍스트 크기 통일 필요, 연도와 동그라미 중앙 정렬
- [ ] 주요 일정 달력 이전달 다음달 버튼 호버 색상 변경 rgb(231,232,239)

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
